### PR TITLE
Should run `npm package` script here if we want `sq` available

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,7 +11,7 @@ tasks:
       npm run compile
     command: |
       cd _squirtle
-      npm run bin
+      npm run package
       cd ../_client
       clear
       npm run start


### PR DESCRIPTION
In the pioneer quest, the `sq` command doesn't appear in our PATH. I think this is the fix we need for that.