### PR TITLE
Auto fund account

### DIFF
--- a/_squirtle/mod.ts
+++ b/_squirtle/mod.ts
@@ -215,7 +215,23 @@ const runPlay = async (argv: any) => {
 ✅ SOROBAN_SECRET_KEY environment variable has been updated
 ------------------------------------------
 Public Key: ${pk} (don't forget to fund me)
-Secret Key: ${sk}`);
+Secret Key: ${sk}`)
+
+  await autoFund(pk)
+}
+
+const autoFund = async(pk: string) => {
+  const fundDecision = await Select.prompt({
+    message: "🏧 Do you want to fund your account now (only needed once)?",
+    options: [
+      { name: "Yes", value: "yes" },
+      { name: "No", value: "no" },
+    ],
+    default: "yes"
+  })
+  if (fundDecision == "yes") {
+    return runFund(pk)
+  }
 }
 
 const runFund = async (argv: any) => {

--- a/_squirtle/mod.ts
+++ b/_squirtle/mod.ts
@@ -224,28 +224,34 @@ const autoFund = async(pk: string) => {
   const accountIsFunded = await fetch(`http://localhost:8000/accounts/${pk}`)
     .then(response => response.status == 200)
 
-  console.log(`\nYour account is ${accountIsFunded?'already':'not'} funded`)
+  console.log('\n')  
   if (accountIsFunded) {
+    console.log(`💰 Your account is already funded!`)
     return
   }
+  console.log(`🚫 Your account is not funded, yet.`)
 
   const fundDecision = await Select.prompt({
     message: "🏧 Do you want to fund your account now (only needed once)?",
     options: [
-      { name: "Yes", value: "yes" },
-      { name: "No", value: "no" },
+      { name: "💁 Yes, I'll take that!", value: "yes" },
+      { name: "🙅 No thanks", value: "no" },
     ],
     default: "yes"
   })
   if (fundDecision == "yes") {
-    return runFund(pk)
+    return doFund(pk)
   }
 }
 
+const doFund = async(pk: string) => {
+  return fetch(`https://friendbot-futurenet.stellar.org/?addr=${pk}`)
+    .then(handleResponse)
+    .catch(printErrorBreak)
+}
+
 const runFund = async (argv: any) => {
-  return fetch(`https://friendbot-futurenet.stellar.org/?addr=${argv.addr}`)
-  .then(handleResponse)
-  .catch(printErrorBreak)
+  return doFund(argv.addr)
 }
 
 const runCheck = async (argv: any) => {

--- a/_squirtle/mod.ts
+++ b/_squirtle/mod.ts
@@ -48,7 +48,6 @@ const runLogin = async () => {
 
     const run2 = Deno.run({
       cmd: ['gp', 'preview', '--external', discordUrl.toString()]
-      // cmd: ['gp', 'preview', '--external', `https://quest.stellar.org/register?gitpod_auth_url=${encodeURIComponent(discordUrl.toString())}`]
     })
     await run2.status()
 
@@ -175,16 +174,6 @@ const runOpen = async () => {
 }
 
 const runPull = async () => {
-  // const run0 = Deno.run({
-  //   cmd: ['pwd'],
-  //   stdout: 'piped'
-  // })
-  // const workingDir = new TextDecoder().decode(await run0.output()).trim()
-  // const [root, directory, workspace] = workingDir.split('/')
-  // const questDirectory = [root, directory, workspace].join('/') + '/quests/'
-
-  // console.log(questDirectory);
-
   const run1 = Deno.run({
     cmd: ['git', 'stash',],
   })
@@ -197,7 +186,6 @@ const runPull = async () => {
 
   const run3 = Deno.run({
     cmd: ['git', 'pull', '-X', 'theirs']
-    // cmd: ['git', 'checkout', 'origin/main', '--theirs', questDirectory],
   })
   await run3.status()
 
@@ -235,28 +223,26 @@ Secret Key: ${sk}`)
   await autoFund(pk)
 }
 
-const autoFund = async(pk: string) => {
+const autoFund = async (pk: string) => {
   const accountIsFunded = await fetch(`http://localhost:8000/accounts/${pk}`)
-    .then(response => response.status == 200)
+  .then(({status}) => status === 200)
 
-  console.log('\n')  
-  if (accountIsFunded) {
-    console.log(`💰 Your account is already funded!`)
+  console.log('------------------------------------------')
+
+  if (accountIsFunded)
     return
-  }
-  console.log(`🚫 Your account is not funded, yet.`)
 
   const fundDecision = await Select.prompt({
-    message: "🏧 Do you want to fund your account now (only needed once)?",
+    message: "🏧 Do you want to fund this account now?",
     options: [
-      { name: "💁 Yes, I'll take that!", value: "yes" },
+      { name: "💁 Yes plese!", value: "yes" },
       { name: "🙅 No thanks", value: "no" },
     ],
     default: "yes"
   })
-  if (fundDecision == "yes") {
+
+  if (fundDecision == "yes")
     return doFund(pk)
-  }
 }
 
 const doFund = async(pk: string) => {
@@ -492,7 +478,6 @@ const submitClaimToken = (claimToken: string, innerTx: string, env: any) => {
     })
   })
     .then(handleResponse)
-    .catch(printErrorBreak)
 }
 
 const handleResponse = async (response: any) => {

--- a/_squirtle/mod.ts
+++ b/_squirtle/mod.ts
@@ -221,6 +221,14 @@ Secret Key: ${sk}`)
 }
 
 const autoFund = async(pk: string) => {
+  const accountIsFunded = await fetch(`http://localhost:8000/accounts/${pk}`)
+    .then(response => response.status == 200)
+
+  console.log(`\nYour account is ${accountIsFunded?'already':'not'} funded`)
+  if (accountIsFunded) {
+    return
+  }
+
   const fundDecision = await Select.prompt({
     message: "🏧 Do you want to fund your account now (only needed once)?",
     options: [


### PR DESCRIPTION
Adds a prompt to ask the user to fund their account once they hit play:
```
gitpod /workspace/soroban-quest--pioneer (auto_fund_account) $ sq play 1
🔐 Quest Keypair for Stellar Quest Series 5 Quest 1
✅ SOROBAN_SECRET_KEY environment variable has been updated
------------------------------------------
Public Key: GC2DQAX7Z5E4NUPC6FCXUP4XMCWFIIINMXSCTWNBJCLYP76CEZPRFZB6 (don't forget to fund me)
Secret Key: SAVVT4ANZCSAZPE7NGDCQCJWQI22ETO4UKDECYJLBGJHL4FCTXFUFWBK


💰 Your account is already funded!
gitpod /workspace/soroban-quest--pioneer (auto_fund_account) $ sq play 2
🔐 Quest Keypair for Stellar Quest Series 5 Quest 2
✅ SOROBAN_SECRET_KEY environment variable has been updated
------------------------------------------
Public Key: GC37ZZCDOLNENETV24ZRIDDMIZCUL2JAPQ2MC3PGFLHDY6WKORQZQDIB (don't forget to fund me)
Secret Key: SAQJCODARFXV25U6T7RPGUPQBAQAMN3PCIA7RYMECHAOUX47FAOKGK7R


🚫 Your account is not funded, yet.
 ? 🏧 Do you want to fund your account now (only needed once)? (💁 Yes, I'll take that!)
 ❯ 💁 Yes, I'll take that!
   🙅 No thanks
```

<a href="https://gitpod.io/#https://github.com/tyvdh/soroban-quest--pioneer/pull/12"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

