### PR TITLE
Minor UX improvements

### DIFF
--- a/_squirtle/mod.ts
+++ b/_squirtle/mod.ts
@@ -249,17 +249,17 @@ const isAccountFunded = async (pk: string): Promise<boolean> => {
     .then(({status}) => status === 200)
 }
 
-const doFund = async(pk: string) => {
+const doFund = (pk: string) => {
   return fetch(`https://friendbot-futurenet.stellar.org/?addr=${pk}`)
     .then(handleResponse)
     .catch(printErrorBreak)
 }
 
-const runFund = async ({ addr }: any) => {
-  const accountIsFunded = await isAccountFunded(addr)
-  if (accountIsFunded)
+const runFund = async (argv: any) => {
+  if (await isAccountFunded(argv.addr))
     return console.log('👀 Your account has already been funded.')
-  return doFund(addr)
+
+  return doFund(argv.addr)
 }
 
 const runCheck = async (argv: any) => {
@@ -361,9 +361,16 @@ const runSubmit = async (argv: any) => {
   const { CLAIM_TOKEN } = env
 
   await submitClaimToken(CLAIM_TOKEN, argv.xdr, env)
-    .then(result => {
-      // TODO: print result.hash once /prize/claim returns it
-      console.log(`✅ Transaction submitted!`)
+    .then(() => {
+      const { hash } = JSON.parse(
+        new TextDecoder().decode(
+          decode(
+            CLAIM_TOKEN.split('.')[1]
+          )
+        )
+      )
+
+      console.log(`✅ Transaction ${hash} submitted!`)
     })
     .catch(async (err) => {
       const { claimToken } = err

--- a/_squirtle/mod.ts
+++ b/_squirtle/mod.ts
@@ -352,6 +352,7 @@ const runCheck = async (argv: any) => {
   }
 
   else if (signPrompt === 'xdr') {
+    console.log('👌 Sign the following XDR and then submit it with: sq submit <signed XDR>')
     console.log(xdr);
   }
 }
@@ -361,6 +362,10 @@ const runSubmit = async (argv: any) => {
   const { CLAIM_TOKEN } = env
 
   await submitClaimToken(CLAIM_TOKEN, argv.xdr, env)
+    .then(result => {
+      // TODO: print result.hash once /prize/claim returns it
+      console.log(`✅ Transaction submitted!`)
+    })
     .catch(async (err) => {
       const { claimToken } = err
 
@@ -489,7 +494,6 @@ const submitClaimToken = (claimToken: string, innerTx: string, env: any) => {
 
 const handleResponse = async (response: any) => {
   const isResponseJson = response.headers.get('content-type')?.indexOf('json') > -1
-
   if (response.ok)
     return isResponseJson
       ? response.json()

--- a/_squirtle/mod.ts
+++ b/_squirtle/mod.ts
@@ -352,7 +352,6 @@ const runCheck = async (argv: any) => {
   }
 
   else if (signPrompt === 'xdr') {
-    console.log('👌 Sign the following XDR and then submit it with: sq submit <signed XDR>')
     console.log(xdr);
   }
 }

--- a/_squirtle/mod.ts
+++ b/_squirtle/mod.ts
@@ -224,8 +224,7 @@ Secret Key: ${sk}`)
 }
 
 const autoFund = async (pk: string) => {
-  const accountIsFunded = await fetch(`http://localhost:8000/accounts/${pk}`)
-  .then(({status}) => status === 200)
+  const accountIsFunded = await isAccountFunded(pk)
 
   if (accountIsFunded)
     return
@@ -245,14 +244,22 @@ const autoFund = async (pk: string) => {
     return doFund(pk)
 }
 
+const isAccountFunded = async (pk: string): Promise<boolean> => {
+  return await fetch(`http://localhost:8000/accounts/${pk}`)
+    .then(({status}) => status === 200)
+}
+
 const doFund = async(pk: string) => {
   return fetch(`https://friendbot-futurenet.stellar.org/?addr=${pk}`)
     .then(handleResponse)
     .catch(printErrorBreak)
 }
 
-const runFund = async (argv: any) => {
-  return doFund(argv.addr)
+const runFund = async ({ addr }: any) => {
+  const accountIsFunded = await isAccountFunded(addr)
+  if (accountIsFunded)
+    return console.log('👀 Your account has already been funded.')
+  return doFund(addr)
 }
 
 const runCheck = async (argv: any) => {


### PR DESCRIPTION
This PR contains 2 commits tackling different improvements (see below) tell me if you want me to split them into 2 PRs.

---

1️⃣ `sq fund` prints a message if an account has already been funded.
 Before we printed the plain friendbot error which confused many many people in Quest 1.
 Not sure why they thought they'd need to fund their account twice but uh printing a nice message should be easier then trying to explain users that this error isn't an error.
 
This command should *hopefully* 🤞 be used less with @hanseartic s change to `sq play` but some people will follow strange tutorials ion telegram groups or Elliots introduction video and we don't need more duplicates of this in #help.

Before this PR:
![grafik](https://user-images.githubusercontent.com/5108989/201528729-7a5c767f-03e0-4ce1-bc4d-db8dcdaed4e5.png)

Now:
![grafik](https://user-images.githubusercontent.com/5108989/201528747-73cf0fb8-e2f4-462e-9e84-ff92ee129e00.png)

2️⃣ ~~Some guidance for claiming prizes using raw XDR signing.
Previously it was confusing to use the raw XDR signing method, even some Lumenauts where confused that they couldn't submit the tx directly so now we show a message telling them to use `sq submit`~~

Also we're showing a message that the transaction with `sq submit` has been submitted successfully:
![grafik](https://user-images.githubusercontent.com/5108989/201529141-0cbcc26b-2c74-4e74-8f28-374bc1a9230e.png)
I'd love to add the tx hash there, but `/prize/claim` seems to not return it and calculating it from the input XDR seems to be too much effort for this improvement.

As always feel free to make suggestion or to edit the changes yourself.




<a href="https://gitpod.io/#https://github.com/tyvdh/soroban-quest--pioneer/pull/14"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

