### PR TITLE
Add horizon status command

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -38,7 +38,7 @@ tasks:
       # This might should be set by the user.
       # This account must actually exist as a funded account on the futurenet.
       SOROBAN_SECRET_KEY: SDUOO3L7CNFXNNWSRSUCEJDKY5CLBZRI23UF6ZNXD23W5NGKJWVMGR7O
-      SOROBAN_RPC_URL: "http://localhost:8000/soroban/rpc"
+      SOROBAN_RPC_URL: "http://127.0.0.1:8000/soroban/rpc"
       SOROBAN_NETWORK_PASSPHRASE: "Test SDF Future Network ; October 2022"
     # To keep things tidy, we clear the terminal from the previous output.
     command: |

--- a/_squirtle/mod.ts
+++ b/_squirtle/mod.ts
@@ -406,7 +406,7 @@ const runSubmit = async (argv: any) => {
 const getRpcStatus = async () => {
   return fetch('http://localhost:8000')
     .then(response => response.json())
-    .then(({ingest_latest_ledger, core_latest_ledger}) => ingest_latest_ledger == core_latest_ledger)
+    .then(({ingest_latest_ledger, core_latest_ledger}) => ingest_latest_ledger === core_latest_ledger)
     .catch(() => false)
 }
 

--- a/_squirtle/mod.ts
+++ b/_squirtle/mod.ts
@@ -1,6 +1,6 @@
 import yargs from 'https://deno.land/x/yargs@v17.6.0-deno/deno.ts';
 import { decode } from "https://deno.land/std@0.161.0/encoding/base64.ts"
-import { Select, Confirm } from "https://deno.land/x/cliffy@v0.25.4/prompt/mod.ts";
+import { Select, Confirm, Input } from "https://deno.land/x/cliffy@v0.25.4/prompt/mod.ts";
 
 const runLogin = async () => {
   let env: any = await getEnv()

--- a/_squirtle/mod.ts
+++ b/_squirtle/mod.ts
@@ -448,7 +448,7 @@ const pickRPCEndpoint = async () => {
     altNet = 'http://127.0.0.1:8000/soroban/rpc'
   
   else if (altNet === 'custom') {
-    const customAltNet = await Input.prompt(`Enter a custom RPC endpoint.\n   (remember to include the protocol, port number and /soroban/rpc path)`);
+    const customAltNet = await Input.prompt(`Enter a custom RPC endpoint. (include the protocol, port number and /soroban/rpc path)`);
 
     if (
       customAltNet.length <= 'http://:65535/soroban/rpc'.length

--- a/_squirtle/mod.ts
+++ b/_squirtle/mod.ts
@@ -402,6 +402,33 @@ const runSubmit = async (argv: any) => {
     })
 }
 
+
+const getRpcStatus = async () => {
+  return fetch('http://localhost:8000')
+    .then(response => response.json())
+   .then(({ingest_latest_ledger}) => ingest_latest_ledger > 0)
+    .catch(() => false)
+}
+
+const runGetRpcStatus = async (argv: any) => {
+  const ready = await getRpcStatus()
+
+  var statusMessage = ''
+  if (ready) {
+    statusMessage = '📡'
+    if (!argv.short) {
+      statusMessage += ' Your local horizon endpoint is ready to accept connections'
+    }
+  } else {
+    statusMessage = '⚙️'
+    if (!argv.short) {
+      statusMessage += ' Your local horizon endpoint is getting ready. It cannot accept and process soroban requests, yet'
+    }
+  }
+
+  console.log(statusMessage)
+}
+
 const runHelp = async () => {
   const run1 = Deno.run({
     cmd: ['sq', 'help'],
@@ -555,6 +582,11 @@ yargs(Deno.args)
       alias: ['tx'],
     })
     .demandOption(['xdr']), runSubmit)
+  .command('horizon', 'Check status of horizon RPC', (yargs: any) => yargs
+    .options('short', {
+      describe: 'only show status icon',
+      alias: ['s']
+    }), runGetRpcStatus)
   .command('*', '', {}, runHelp)
   .showHelpOnFail(false)
   .demandCommand(1)

--- a/_squirtle/mod.ts
+++ b/_squirtle/mod.ts
@@ -406,7 +406,7 @@ const runSubmit = async (argv: any) => {
 const getRpcStatus = async () => {
   return fetch('http://localhost:8000')
     .then(response => response.json())
-   .then(({ingest_latest_ledger}) => ingest_latest_ledger > 0)
+    .then(({ingest_latest_ledger, core_latest_ledger}) => ingest_latest_ledger == core_latest_ledger)
     .catch(() => false)
 }
 

--- a/_squirtle/mod.ts
+++ b/_squirtle/mod.ts
@@ -403,27 +403,45 @@ const runSubmit = async (argv: any) => {
 }
 
 
-const getRpcStatus = async () => {
+const getRpcStatus = () => {
   return fetch('http://localhost:8000')
-    .then(response => response.json())
+    .then(handleResponse)
     .then(({ingest_latest_ledger, core_latest_ledger}) => ingest_latest_ledger === core_latest_ledger)
     .catch(() => false)
 }
 
 const runGetRpcStatus = async (argv: any) => {
-  const ready = await getRpcStatus()
+  const ready = false // await getRpcStatus()
 
-  var statusMessage = ''
+  let statusMessage = ''
+
+  // TODO if we're ready but using a SOROBAN_RPC_URL that isn't the Gitpod's ask if we want to revert (or maybe just revert by automatically?)
+
   if (ready) {
     statusMessage = '📡'
-    if (!argv.short) {
-      statusMessage += ' Your local horizon endpoint is ready to accept connections'
-    }
+    if (!argv.short)
+      statusMessage += ' Your local horizon endpoint is ready!'
   } else {
-    statusMessage = '⚙️'
-    if (!argv.short) {
-      statusMessage += ' Your local horizon endpoint is getting ready. It cannot accept and process soroban requests, yet'
-    }
+    statusMessage = '⏳'
+    if (!argv.short)
+      statusMessage += ' Your local horizon endpoint is not yet ready'
+
+    const altNet = await Select.prompt({
+      message: "Would you like to continue with one of our official endpoints?",
+      options: [
+        { name: "No", value: "no" },
+        // TODO support a write in option that if selected let's up paste in your own SOROBAN_RPC_URL endpoint (for the Kais and Overcats out there)
+        { name: "KanayeNet", value: "https://kanaye-futurenet.stellar.quest:443/soroban/rpc" },
+        { name: "nebolsin", value: "https://nebolsin-futurenet.stellar.quest:443/soroban/rpc" },
+        { name: "kalepail", value: "https://kalepail-futurenet.stellar.quest:443/soroban/rpc" },
+        { name: "silence", value: "https://silence-futurenet.stellar.quest:443/soroban/rpc" },
+        { name: "Raph", value: "https://raph-futurenet.stellar.quest:443/soroban/rpc" },
+        { name: "nesho", value: "https://nesho-futurenet.stellar.quest:443/soroban/rpc" },
+      ],
+      default: "no"
+    });
+
+    console.log(altNet) // TODO update the SOROBAN_RPC_URL but only in the CLI - Futurenet (may require an update to the bash-hook)
   }
 
   console.log(statusMessage)

--- a/_squirtle/mod.ts
+++ b/_squirtle/mod.ts
@@ -415,14 +415,14 @@ const runSubmit = async (argv: any) => {
     })
 }
 
-const getRpcStatus = () => {
+const getRPCStatus = () => {
   return fetch('http://127.0.0.1:8000')
     .then(handleResponse)
     .then(({ingest_latest_ledger, core_latest_ledger}) => ingest_latest_ledger === core_latest_ledger)
     .catch(() => false)
 }
 
-const pickRpcEndpoint = async () => {
+const pickRPCEndpoint = async () => {
   let altNet = await Select.prompt({
     message: "Would you like to switch to one of our official endpoints?",
     options: [
@@ -447,7 +447,7 @@ const pickRpcEndpoint = async () => {
     if (
       customAltNet.length <= 'http://:65535/soroban/rpc'.length
       || !customAltNet.includes('/soroban/rpc')
-    ) console.log(`❌ Invalid RPC URL`)
+    ) console.log(`❌ Invalid RPC endpoint`)
     else altNet = customAltNet
   }
 
@@ -456,9 +456,9 @@ const pickRpcEndpoint = async () => {
 
 const runCheckRPC = async (argv: any) => {
   if (argv.change)
-    return pickRpcEndpoint()
+    return pickRPCEndpoint()
 
-  const ready = await getRpcStatus()
+  const ready = await getRPCStatus()
 
   let statusMessage = ''
 
@@ -481,7 +481,7 @@ const runCheckRPC = async (argv: any) => {
 
     console.log(statusMessage)
 
-    return pickRpcEndpoint()
+    return pickRPCEndpoint()
   }
 }
 

--- a/_squirtle/mod.ts
+++ b/_squirtle/mod.ts
@@ -245,7 +245,7 @@ const autoFund = async (pk: string) => {
 }
 
 const isAccountFunded = async (pk: string): Promise<boolean> => {
-  return await fetch(`http://localhost:8000/accounts/${pk}`)
+  return await fetch(`http://127.0.0.1:8000/accounts/${pk}`)
     .then(({status}) => status === 200)
 }
 
@@ -416,7 +416,7 @@ const runSubmit = async (argv: any) => {
 }
 
 const getRpcStatus = () => {
-  return fetch('http://localhost:8000')
+  return fetch('http://127.0.0.1:8000')
     .then(handleResponse)
     .then(({ingest_latest_ledger, core_latest_ledger}) => ingest_latest_ledger === core_latest_ledger)
     .catch(() => false)
@@ -427,7 +427,7 @@ const runHorizon = async (argv: any) => {
 
   let statusMessage = ''
 
-  // TODO if we're ready but using a SOROBAN_RPC_URL that isn't the Gitpod's ask if we want to revert (or maybe just revert by automatically?)
+  // TODO if we're ready but using a SOROBAN_RPC_URL that isn't the Gitpod's ask if we want to revert (or maybe just revert automatically?)
 
   if (ready) {
     statusMessage = '📡'
@@ -436,7 +436,9 @@ const runHorizon = async (argv: any) => {
       statusMessage += ' Your local horizon endpoint is ready!'
     
       console.log(statusMessage)
-  } else {
+  } 
+  
+  else {
     statusMessage = '⏳'
     
     if (!argv.short)
@@ -454,22 +456,25 @@ const runHorizon = async (argv: any) => {
         { name: "silence", value: "https://silence-futurenet.stellar.quest:443/soroban/rpc" },
         { name: "Raph", value: "https://raph-futurenet.stellar.quest:443/soroban/rpc" },
         { name: "nesho", value: "https://nesho-futurenet.stellar.quest:443/soroban/rpc" },
-        { name: "Custom", value: "custom" }, // TODO support a write in option that if selected let's up paste in your own SOROBAN_RPC_URL endpoint (for the Kais and Overcats out there)
+        { name: "Custom", value: "custom" },
       ],
       default: "no"
     });
 
     if (altNet === 'no')
-      return
+      altNet = 'http://127.0.0.1:8000/soroban/rpc'
+    
+    else if (altNet === 'custom') {
+      const customAltNet = await Input.prompt(`Enter a custom RPC endpoint.\n   (remember to include the protocol, port number and /soroban/rpc path)`);
 
-    else {
-      if (altNet === 'custom')
-        altNet = await Input.prompt(`Enter a custom RPC endpoint.\n   (remember to include the protocol, port number and /soroban/rpc path)`);
+      if (
+        customAltNet.length <= 'http://:65535/soroban/rpc'.length
+        || !customAltNet.includes('/soroban/rpc')
+      ) console.log(`❌ Invalid RPC URL`)
+      else altNet = customAltNet
     }
 
     await Deno.writeFile("/workspace/.soroban-rpc-url", new TextEncoder().encode(altNet))
-
-    // console.log(altNet) // TODO update the SOROBAN_RPC_URL but only in the CLI - Futurenet (may require an update to the bash-hook)
   }
 }
 

--- a/_squirtle/package-lock.json
+++ b/_squirtle/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "_squirtle",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Add `sq horizon` command that allows quick check if the futurenet RPC is ready.

Allows users to quickly check if horizon is ready to accept connections:

Horizon not ready yet:
```
gitpod /workspace/soroban-quest (main) $ sq horizon
⚙️  Your local horizon endpoint is getting ready. It cannot accept and process soroban requests, yet
gitpod /workspace/soroban-quest (main) $
```

After horizon is ready:
```
gitpod /workspace/soroban-quest (main) $ sq horizon
📡 Your local horizon endpoint is ready to accept connections
gitpod /workspace/soroban-quest (main) $ 
```


There's also a `--short` flag 
```
gitpod /workspace/soroban-quest (main) $ sq horizon -s
📡
gitpod /workspace/soroban-quest (main) $ 
```

that could allow pulling that status into prompt like this:
```
gitpod /workspace/soroban-quest (main) ⚙️ $ sleep 100
gitpod /workspace/soroban-quest (main) 📡 $
```

<a href="https://gitpod.io/#https://github.com/tyvdh/soroban-quest--pioneer/pull/15"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

