### PR TITLE
adds bash-rpc-prompt

### DIFF
--- a/_squirtle/bash-rpc-prompt
+++ b/_squirtle/bash-rpc-prompt
@@ -1,0 +1,2 @@
+
+export PS1="\$(sq rpc -s) ${PS1}"


### PR DESCRIPTION
Adds a file that can be source'd to add rpc-status to prompt:

```
gitpod /workspace/soroban-quest (main) $ source ~/.local/bash-rpc-prompt
⏳ gitpod /workspace/soroban-quest (main) $ sq rpc -s
⏳
⏳ gitpod /workspace/soroban-quest (main) $ sq rpc -s
📡
📡 gitpod /workspace/soroban-quest (main) $
```


<a href="https://gitpod.io/#https://github.com/tyvdh/soroban-quest--pioneer/pull/20"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

